### PR TITLE
Fix `vagrant up` error

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
 -r base.txt
 tox
-ipython
+ipython < 6.0


### PR DESCRIPTION
Vagrant can't provision a machine

```
    default: + sudo docker run --link devel-backend:devel-backend --volumes-from devel-backend --name devel-webserver -d -p 80:80 brainless/devel-webserver:0.1
    default: cf5476c08fa6e84b674b913039111baef273c7e3bc14f4cf6da93fd139447eaa
    default: docker: Error response from daemon: Cannot link to a non running container: /devel-backend AS /devel-webserver/devel-backend.
```
It happens due to `devel-backend` container fail

```
IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.

When using Python 2.7, please install IPython 5.x LTS Long Term Support version.

Beginning with IPython 6.0, Python 3.3 and above is required.
```

Quick fix is a ipython version restriction. 

Signed-off-by: Rinat Sabitov <rinat.sabitov@gmail.com>